### PR TITLE
Include the function pointer in `Redispatch<R>`

### DIFF
--- a/node/src/automaton/action.rs
+++ b/node/src/automaton/action.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_derive::{Deserialize, Serialize};
 use std::{
     any::{Any, TypeId},
+    borrow::Cow,
     collections::VecDeque,
     fmt,
     fs::{File, OpenOptions},
@@ -115,14 +116,14 @@ pub struct SerializableAction<T: Clone + type_uuid::TypeUuid + std::fmt::Debug +
 pub struct Redispatch<R> {
     #[serde(skip)]
     fun_ptr: Option<fn(R) -> AnyAction>,
-    pub fun_name: String,
+    pub fun_name: Cow<'static, str>,
 }
 
 impl<R: 'static> Redispatch<R> {
-    pub fn new(name: &str, ptr: fn(R) -> AnyAction) -> Self {
+    pub fn new(name: &'static str, ptr: fn(R) -> AnyAction) -> Self {
         Self {
             fun_ptr: Some(ptr),
-            fun_name: name.to_string(),
+            fun_name: Cow::Borrowed(name),
         }
     }
 


### PR DESCRIPTION
To avoid iterating on the whole `CALLBACKS` in `Redispatch::make` and avoid boxing the result into a `Box<dyn Any>`.

That pointer won't be de/serialized, in that case `Redispatch::make` will iterate on `CALLBACKS` to find the pointer